### PR TITLE
chore: use PrivacyGatewayErrorEnum from common-types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,15 @@
       "version": "0.34.0",
       "license": "ISC",
       "dependencies": {
-        "@arianee/arianee-access-token": "1.47.0",
-        "@arianee/arianee-api-client": "1.47.0",
-        "@arianee/arianee-privacy-gateway-client": "1.47.0",
-        "@arianee/arianee-protocol-client": "1.47.0",
-        "@arianee/core": "1.47.0",
-        "@arianee/creator": "1.47.0",
-        "@arianee/utils": "1.47.0",
+        "@arianee/arianee-access-token": "1.48.0",
+        "@arianee/arianee-api-client": "1.48.0",
+        "@arianee/arianee-privacy-gateway-client": "1.48.0",
+        "@arianee/arianee-protocol-client": "1.48.0",
+        "@arianee/common-types": "^1.48.0",
+        "@arianee/core": "1.48.0",
+        "@arianee/creator": "1.48.0",
+        "@arianee/utils": "1.48.0",
+        "@arianee/wallet": "1.48.0",
         "axios": "^1.6.0",
         "ethers": "^6.8.1",
         "express": "^4.18.2",
@@ -25,7 +27,6 @@
         "jrpc": "^3.1.2"
       },
       "devDependencies": {
-        "@arianee/wallet": "1.47.0",
         "@types/jest": "^29.5.8",
         "@types/node": "^12.20.55",
         "body-parser": "^1.20.2",
@@ -159,9 +160,9 @@
       }
     },
     "node_modules/@arianee/arianee-access-token": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/arianee-access-token/-/arianee-access-token-1.47.0.tgz",
-      "integrity": "sha512-lUih2wdAXWBIjvOHYAyL8GdexskhOm+L8cyjw6iGKKHLxjZGioQe5LMHrzAkAEFx2onc8yF8j7Kp913gkNvctA==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/arianee-access-token/-/arianee-access-token-1.48.0.tgz",
+      "integrity": "sha512-rfTXyyscNJH/E/m/sMZZXZkKdk+Jwq/ZMoLfQP6VyapRzJpDMvmlYo8U9AhtBBuEHQbPJeNkcLG3CJO/qE/HSA==",
       "dependencies": {
         "@arianee/0xcert-cert": "^2.0.2",
         "@arianee/arianee-abi": "0.22.0",
@@ -174,10 +175,10 @@
         "ts-invariant": "^0.10.3"
       },
       "peerDependencies": {
-        "@arianee/common-types": "1.47.0",
-        "@arianee/core": "1.47.0",
-        "@arianee/permit721-sdk": "1.47.0",
-        "@arianee/utils": "1.47.0",
+        "@arianee/common-types": "1.48.0",
+        "@arianee/core": "1.48.0",
+        "@arianee/permit721-sdk": "1.48.0",
+        "@arianee/utils": "1.48.0",
         "tslib": "2.5.0"
       }
     },
@@ -235,9 +236,9 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@arianee/arianee-api-client": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/arianee-api-client/-/arianee-api-client-1.47.0.tgz",
-      "integrity": "sha512-PW9S2m9nJSyE1C2hVnXLFLv+8My2gR7iSm+Uy75lZ61RRduWbBxZlZ0bYTMLTrVR2UBqpWvjwRawpi3ZpaFBZA==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/arianee-api-client/-/arianee-api-client-1.48.0.tgz",
+      "integrity": "sha512-9iChfg8FQ5tiSEO3vUD3nBj8JdOUhh0RqVYgNpWp7YAUgIbb9eTWK9GDYx2cSgNfJMUPTA4vXKz9A8TMWEdoMg==",
       "dependencies": {
         "@arianee/0xcert-cert": "^2.0.2",
         "@arianee/arianee-abi": "0.22.0",
@@ -246,8 +247,8 @@
         "node-fetch": "^2.6.12"
       },
       "peerDependencies": {
-        "@arianee/common-types": "1.47.0",
-        "@arianee/utils": "1.47.0",
+        "@arianee/common-types": "1.48.0",
+        "@arianee/utils": "1.48.0",
         "tslib": "2.5.0"
       }
     },
@@ -305,9 +306,9 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@arianee/arianee-privacy-gateway-client": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/arianee-privacy-gateway-client/-/arianee-privacy-gateway-client-1.47.0.tgz",
-      "integrity": "sha512-G8iX6SEUYAGsdJBChr88TBi1d68fNldyzMYqxHe6IMJqvkFYMUe8C8pW0d4I2h7FZJ4QOHCd8PeRPiqbq6vUbg==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/arianee-privacy-gateway-client/-/arianee-privacy-gateway-client-1.48.0.tgz",
+      "integrity": "sha512-rtyofBBPaU+I5GrdnG3tPHfF1z4QqQ14llsfa03RaxDhpDR7lh+UvZwtTTPyY32hH94hlMJYN5p5oSQWS7bSTg==",
       "dependencies": {
         "@arianee/0xcert-cert": "^2.0.2",
         "@arianee/arianee-abi": "0.22.0",
@@ -320,11 +321,11 @@
         "ts-invariant": "^0.10.3"
       },
       "peerDependencies": {
-        "@arianee/arianee-access-token": "1.47.0",
-        "@arianee/common-types": "1.47.0",
-        "@arianee/core": "1.47.0",
-        "@arianee/permit721-sdk": "1.47.0",
-        "@arianee/utils": "1.47.0",
+        "@arianee/arianee-access-token": "1.48.0",
+        "@arianee/common-types": "1.48.0",
+        "@arianee/core": "1.48.0",
+        "@arianee/permit721-sdk": "1.48.0",
+        "@arianee/utils": "1.48.0",
         "tslib": "2.5.0"
       }
     },
@@ -382,9 +383,9 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@arianee/arianee-protocol-client": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/arianee-protocol-client/-/arianee-protocol-client-1.47.0.tgz",
-      "integrity": "sha512-nj11xZL853wdJs2Og1uc9ekuMicNdZpHebr++UKT2iCRz1eZWbZxrB7xifsccqi76XpdQEbzKN/V5H8GOF+Hyg==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/arianee-protocol-client/-/arianee-protocol-client-1.48.0.tgz",
+      "integrity": "sha512-uWjWh4ypdszf6aj3IPQhAEpY5l33KWbJMd3onsPwmuqgZUvpDL+G2wItLz9tdPeL6vr5peXpRhZZyWk1qF7YkA==",
       "dependencies": {
         "@arianee/0xcert-cert": "^2.0.2",
         "@arianee/arianee-abi": "0.22.0",
@@ -399,11 +400,11 @@
         "ts-invariant": "^0.10.3"
       },
       "peerDependencies": {
-        "@arianee/arianee-api-client": "1.47.0",
-        "@arianee/common-types": "1.47.0",
-        "@arianee/core": "1.47.0",
-        "@arianee/permit721-sdk": "1.47.0",
-        "@arianee/utils": "1.47.0",
+        "@arianee/arianee-api-client": "1.48.0",
+        "@arianee/common-types": "1.48.0",
+        "@arianee/core": "1.48.0",
+        "@arianee/permit721-sdk": "1.48.0",
+        "@arianee/utils": "1.48.0",
         "tslib": "2.5.0"
       }
     },
@@ -461,10 +462,9 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@arianee/common-types": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/common-types/-/common-types-1.47.0.tgz",
-      "integrity": "sha512-kzVsAJ+pBvQH4rINL/zYovhQU4yVGHA96l8QvVIg3eg49OIrgByX39esbnbCPX0H3vnE6XOFqwJLGNg4hu5eKA==",
-      "peer": true,
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/common-types/-/common-types-1.48.0.tgz",
+      "integrity": "sha512-3IB8mmYtIS1b6pZXx6C0enw3OoJDMASFgTW75KVj8IWwIoQkCAM/YN0p8oiYrar4lVnaLkSn76ERrPaHU1Fx3g==",
       "peerDependencies": {
         "tslib": "2.5.0"
       }
@@ -479,9 +479,9 @@
       }
     },
     "node_modules/@arianee/core": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/core/-/core-1.47.0.tgz",
-      "integrity": "sha512-tluRG0JVjmIE3Zz4m76izHhcSaUtBfg+GMrI5u3zpl+ChE91Vt662V/6NCqqeAI5EUnZZYAa9RohxMNtubMY8g==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/core/-/core-1.48.0.tgz",
+      "integrity": "sha512-wyAqNoEf5UO4bU1J41EYiDaRzJHZ5qMETRnz2P/F53nUb3bqPrfLzRMcgfHR1RxiAnYaryKh7Pe9O/GwwBvkYg==",
       "dependencies": {
         "ethers": "6.7.0"
       },
@@ -543,9 +543,9 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@arianee/creator": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/creator/-/creator-1.47.0.tgz",
-      "integrity": "sha512-IxlMPOb7iQPusWiMzluGCDGw7hS4uERA0jmBDgwJLHHuwSUyN0+wdyTOZksayHCKaXlqjp7rM/O60sBOPnbGIA==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/creator/-/creator-1.48.0.tgz",
+      "integrity": "sha512-XMCJEOnQtxnpbuY/1C+XZfSe3IgXLwUbhvhCdKYYBGzUs2F2WR8J8Bbwo1NTEXCo2LekbcMXnjsP9GBirI4N3w==",
       "dependencies": {
         "@arianee/0xcert-cert": "^2.0.2",
         "@arianee/arianee-abi": "0.22.0",
@@ -560,14 +560,14 @@
         "ts-invariant": "^0.10.3"
       },
       "peerDependencies": {
-        "@arianee/arianee-access-token": "1.47.0",
-        "@arianee/arianee-api-client": "1.47.0",
-        "@arianee/arianee-privacy-gateway-client": "1.47.0",
-        "@arianee/arianee-protocol-client": "1.47.0",
-        "@arianee/common-types": "1.47.0",
-        "@arianee/core": "1.47.0",
-        "@arianee/permit721-sdk": "1.47.0",
-        "@arianee/utils": "1.47.0",
+        "@arianee/arianee-access-token": "1.48.0",
+        "@arianee/arianee-api-client": "1.48.0",
+        "@arianee/arianee-privacy-gateway-client": "1.48.0",
+        "@arianee/arianee-protocol-client": "1.48.0",
+        "@arianee/common-types": "1.48.0",
+        "@arianee/core": "1.48.0",
+        "@arianee/permit721-sdk": "1.48.0",
+        "@arianee/utils": "1.48.0",
         "tslib": "2.5.0"
       }
     },
@@ -638,9 +638,9 @@
       "integrity": "sha512-ytPc6eLGcHHnapAZ9S+5qsdomhjo6QBHTDRRBFfTxXIpsicMhVPouPgmUPebZZZGX7vt9USA+Z+0M0dSVtSUEA=="
     },
     "node_modules/@arianee/permit721-sdk": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/permit721-sdk/-/permit721-sdk-1.47.0.tgz",
-      "integrity": "sha512-T7tBJGObeqbt4oPY2PcYjqIfOj6qXcbDLlQHe1qv0yBt2ARmx53NYSK+5dXbqgNvFVrvtl4wLOj+Y3nOa/Ryeg==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/permit721-sdk/-/permit721-sdk-1.48.0.tgz",
+      "integrity": "sha512-zY0uirzCjF7EfSAeCVABGOlsX8F0hvp9Y7Cz2PLXiRXN7ugg+1W+dOC20KaBU2whdYZxsaMzPZm5Sz0Fz5z+BA==",
       "peer": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -712,10 +712,9 @@
       "peer": true
     },
     "node_modules/@arianee/token-provider": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/token-provider/-/token-provider-1.47.0.tgz",
-      "integrity": "sha512-hVDNiuH8QegM1rO5w7APy9TGTYTdw6luKt/4Xd4betFMJTCK50xnJq6y3JL/9E402U2ggjytgUPtOJOfoFsi8w==",
-      "dev": true,
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/token-provider/-/token-provider-1.48.0.tgz",
+      "integrity": "sha512-NjNSEFSYZBwPWSkuYfffSa+J1rml0NDSn2bFrcTWFA5LTf9IWRwOMTuoIP+XcgGzfW2DIutgcIe+9yc+3MuXOA==",
       "peer": true,
       "dependencies": {
         "@arianee/0xcert-cert": "^2.0.2",
@@ -731,13 +730,13 @@
         "ts-invariant": "^0.10.3"
       },
       "peerDependencies": {
-        "@arianee/arianee-access-token": "1.47.0",
-        "@arianee/arianee-api-client": "1.47.0",
-        "@arianee/arianee-protocol-client": "1.47.0",
-        "@arianee/common-types": "1.47.0",
-        "@arianee/core": "1.47.0",
-        "@arianee/permit721-sdk": "1.47.0",
-        "@arianee/utils": "1.47.0",
+        "@arianee/arianee-access-token": "1.48.0",
+        "@arianee/arianee-api-client": "1.48.0",
+        "@arianee/arianee-protocol-client": "1.48.0",
+        "@arianee/common-types": "1.48.0",
+        "@arianee/core": "1.48.0",
+        "@arianee/permit721-sdk": "1.48.0",
+        "@arianee/utils": "1.48.0",
         "tslib": "2.5.0"
       }
     },
@@ -745,14 +744,12 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz",
       "integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==",
-      "dev": true,
       "peer": true
     },
     "node_modules/@arianee/token-provider/node_modules/@noble/hashes": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
       "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -765,14 +762,12 @@
       "version": "18.15.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
       "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
-      "dev": true,
       "peer": true
     },
     "node_modules/@arianee/token-provider/node_modules/ethers": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.7.0.tgz",
       "integrity": "sha512-pxt5hK82RNwcTX2gOZP81t6qVPVspnkpeivwEgQuK9XUvbNtghBnT8GNIb/gPh+WnVSfi8cXC9XlfT8sqc6D6w==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -801,13 +796,12 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true,
       "peer": true
     },
     "node_modules/@arianee/utils": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/utils/-/utils-1.47.0.tgz",
-      "integrity": "sha512-YkjRSRiqc4QoRsCjvecFVgyi6uhaFXtjSZDFy17DDN//hS2Qwpfx5SknnDEWK23CJINLhxQIzWhmm2hax0jsig==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/utils/-/utils-1.48.0.tgz",
+      "integrity": "sha512-pCUazyeJ6N0jRC6FLrQZfz4f8guEVxANXuFuFJyBbUDrU8Cp5rCR/0ExVQSBc3mIbsvN2O4ZLgXk/2HE8K9zkw==",
       "dependencies": {
         "@arianee/0xcert-cert": "^2.0.2",
         "@arianee/arianee-abi": "0.22.0",
@@ -816,7 +810,7 @@
         "node-fetch": "^2.6.12"
       },
       "peerDependencies": {
-        "@arianee/common-types": "1.47.0",
+        "@arianee/common-types": "1.48.0",
         "tslib": "2.5.0"
       }
     },
@@ -874,10 +868,9 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@arianee/wallet": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/wallet/-/wallet-1.47.0.tgz",
-      "integrity": "sha512-Wq4VI9EXQ3wrs3bSUCqytJm2uPNovSwonqVaDulsL5BU+McVCRnZ8V1dZ5EFUEMLdzZLbphKbfcndpgWqdWGjg==",
-      "dev": true,
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/wallet/-/wallet-1.48.0.tgz",
+      "integrity": "sha512-Q6Z4bWldA/4oJCli6MvjzWyEw8cJIJUt/1gk0GU/ewhFXoQ6mL6u4pAFMmq6NaTk5GX0iHOTeas18ykDLFzEHg==",
       "dependencies": {
         "@arianee/0xcert-cert": "^2.0.2",
         "@arianee/arianee-abi": "0.22.0",
@@ -893,35 +886,33 @@
         "ts-invariant": "^0.10.3"
       },
       "peerDependencies": {
-        "@arianee/arianee-access-token": "1.47.0",
-        "@arianee/arianee-api-client": "1.47.0",
-        "@arianee/arianee-protocol-client": "1.47.0",
-        "@arianee/common-types": "1.47.0",
-        "@arianee/core": "1.47.0",
-        "@arianee/permit721-sdk": "1.47.0",
-        "@arianee/token-provider": "1.47.0",
-        "@arianee/utils": "1.47.0",
-        "@arianee/wallet-abstraction": "1.47.0",
-        "@arianee/wallet-api-client": "1.47.0",
+        "@arianee/arianee-access-token": "1.48.0",
+        "@arianee/arianee-api-client": "1.48.0",
+        "@arianee/arianee-protocol-client": "1.48.0",
+        "@arianee/common-types": "1.48.0",
+        "@arianee/core": "1.48.0",
+        "@arianee/permit721-sdk": "1.48.0",
+        "@arianee/token-provider": "1.48.0",
+        "@arianee/utils": "1.48.0",
+        "@arianee/wallet-abstraction": "1.48.0",
+        "@arianee/wallet-api-client": "1.48.0",
         "tslib": "2.5.0"
       }
     },
     "node_modules/@arianee/wallet-abstraction": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/wallet-abstraction/-/wallet-abstraction-1.47.0.tgz",
-      "integrity": "sha512-qb5Y/OCqdy/YsCUTdlf/Bz1xXM0uG2TEfBJh8Wa20jWWOzwA9CpTKOgiqklyO2ufc+IDJ6G/+Q+dMts6Qh7+Eg==",
-      "dev": true,
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/wallet-abstraction/-/wallet-abstraction-1.48.0.tgz",
+      "integrity": "sha512-E79pfy+Au+2owpQrCwNz50aaIAmIbIGmFllHP0E7OJ7tIiXpbx+NbRkgBx0FZvMD2bI1PQeczIpRoKJZlim3FA==",
       "peer": true,
       "peerDependencies": {
-        "@arianee/common-types": "1.47.0",
+        "@arianee/common-types": "1.48.0",
         "tslib": "2.5.0"
       }
     },
     "node_modules/@arianee/wallet-api-client": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/wallet-api-client/-/wallet-api-client-1.47.0.tgz",
-      "integrity": "sha512-0Oiv0dQVqR7yx+scol7lKYJXAJaCKKzaDkqWoWZGlFnxLbelGHJ2XUv19ePqn6UlBQLaiwSbunPa1dbyOUfV2w==",
-      "dev": true,
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/wallet-api-client/-/wallet-api-client-1.48.0.tgz",
+      "integrity": "sha512-IMKbT2wP0ZhKcj0U1VAq7dVdF7JhNdVdlEoVZcO7B5QMklqAExh15a/EmZoZtc4/Hxw5MGtJssgd2/VjwvfE7g==",
       "peer": true,
       "dependencies": {
         "@arianee/0xcert-cert": "^2.0.2",
@@ -935,12 +926,12 @@
         "ts-invariant": "^0.10.3"
       },
       "peerDependencies": {
-        "@arianee/arianee-access-token": "1.47.0",
-        "@arianee/common-types": "1.47.0",
-        "@arianee/core": "1.47.0",
-        "@arianee/permit721-sdk": "1.47.0",
-        "@arianee/utils": "1.47.0",
-        "@arianee/wallet-abstraction": "1.47.0",
+        "@arianee/arianee-access-token": "1.48.0",
+        "@arianee/common-types": "1.48.0",
+        "@arianee/core": "1.48.0",
+        "@arianee/permit721-sdk": "1.48.0",
+        "@arianee/utils": "1.48.0",
+        "@arianee/wallet-abstraction": "1.48.0",
         "tslib": "2.5.0"
       }
     },
@@ -948,14 +939,12 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz",
       "integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==",
-      "dev": true,
       "peer": true
     },
     "node_modules/@arianee/wallet-api-client/node_modules/@noble/hashes": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
       "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -968,14 +957,12 @@
       "version": "18.15.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
       "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
-      "dev": true,
       "peer": true
     },
     "node_modules/@arianee/wallet-api-client/node_modules/ethers": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.7.0.tgz",
       "integrity": "sha512-pxt5hK82RNwcTX2gOZP81t6qVPVspnkpeivwEgQuK9XUvbNtghBnT8GNIb/gPh+WnVSfi8cXC9XlfT8sqc6D6w==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1004,20 +991,17 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true,
       "peer": true
     },
     "node_modules/@arianee/wallet/node_modules/@adraffy/ens-normalize": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz",
-      "integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==",
-      "dev": true
+      "integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg=="
     },
     "node_modules/@arianee/wallet/node_modules/@noble/hashes": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
       "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1028,14 +1012,12 @@
     "node_modules/@arianee/wallet/node_modules/@types/node": {
       "version": "18.15.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
-      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
-      "dev": true
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
     },
     "node_modules/@arianee/wallet/node_modules/ethers": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.7.0.tgz",
       "integrity": "sha512-pxt5hK82RNwcTX2gOZP81t6qVPVspnkpeivwEgQuK9XUvbNtghBnT8GNIb/gPh+WnVSfi8cXC9XlfT8sqc6D6w==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1062,8 +1044,7 @@
     "node_modules/@arianee/wallet/node_modules/ethers/node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.22.13",
@@ -4399,8 +4380,7 @@
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "dev": true
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -9625,9 +9605,9 @@
       }
     },
     "@arianee/arianee-access-token": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/arianee-access-token/-/arianee-access-token-1.47.0.tgz",
-      "integrity": "sha512-lUih2wdAXWBIjvOHYAyL8GdexskhOm+L8cyjw6iGKKHLxjZGioQe5LMHrzAkAEFx2onc8yF8j7Kp913gkNvctA==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/arianee-access-token/-/arianee-access-token-1.48.0.tgz",
+      "integrity": "sha512-rfTXyyscNJH/E/m/sMZZXZkKdk+Jwq/ZMoLfQP6VyapRzJpDMvmlYo8U9AhtBBuEHQbPJeNkcLG3CJO/qE/HSA==",
       "requires": {
         "@arianee/0xcert-cert": "^2.0.2",
         "@arianee/arianee-abi": "0.22.0",
@@ -9679,9 +9659,9 @@
       }
     },
     "@arianee/arianee-api-client": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/arianee-api-client/-/arianee-api-client-1.47.0.tgz",
-      "integrity": "sha512-PW9S2m9nJSyE1C2hVnXLFLv+8My2gR7iSm+Uy75lZ61RRduWbBxZlZ0bYTMLTrVR2UBqpWvjwRawpi3ZpaFBZA==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/arianee-api-client/-/arianee-api-client-1.48.0.tgz",
+      "integrity": "sha512-9iChfg8FQ5tiSEO3vUD3nBj8JdOUhh0RqVYgNpWp7YAUgIbb9eTWK9GDYx2cSgNfJMUPTA4vXKz9A8TMWEdoMg==",
       "requires": {
         "@arianee/0xcert-cert": "^2.0.2",
         "@arianee/arianee-abi": "0.22.0",
@@ -9729,9 +9709,9 @@
       }
     },
     "@arianee/arianee-privacy-gateway-client": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/arianee-privacy-gateway-client/-/arianee-privacy-gateway-client-1.47.0.tgz",
-      "integrity": "sha512-G8iX6SEUYAGsdJBChr88TBi1d68fNldyzMYqxHe6IMJqvkFYMUe8C8pW0d4I2h7FZJ4QOHCd8PeRPiqbq6vUbg==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/arianee-privacy-gateway-client/-/arianee-privacy-gateway-client-1.48.0.tgz",
+      "integrity": "sha512-rtyofBBPaU+I5GrdnG3tPHfF1z4QqQ14llsfa03RaxDhpDR7lh+UvZwtTTPyY32hH94hlMJYN5p5oSQWS7bSTg==",
       "requires": {
         "@arianee/0xcert-cert": "^2.0.2",
         "@arianee/arianee-abi": "0.22.0",
@@ -9783,9 +9763,9 @@
       }
     },
     "@arianee/arianee-protocol-client": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/arianee-protocol-client/-/arianee-protocol-client-1.47.0.tgz",
-      "integrity": "sha512-nj11xZL853wdJs2Og1uc9ekuMicNdZpHebr++UKT2iCRz1eZWbZxrB7xifsccqi76XpdQEbzKN/V5H8GOF+Hyg==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/arianee-protocol-client/-/arianee-protocol-client-1.48.0.tgz",
+      "integrity": "sha512-uWjWh4ypdszf6aj3IPQhAEpY5l33KWbJMd3onsPwmuqgZUvpDL+G2wItLz9tdPeL6vr5peXpRhZZyWk1qF7YkA==",
       "requires": {
         "@arianee/0xcert-cert": "^2.0.2",
         "@arianee/arianee-abi": "0.22.0",
@@ -9839,10 +9819,9 @@
       }
     },
     "@arianee/common-types": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/common-types/-/common-types-1.47.0.tgz",
-      "integrity": "sha512-kzVsAJ+pBvQH4rINL/zYovhQU4yVGHA96l8QvVIg3eg49OIrgByX39esbnbCPX0H3vnE6XOFqwJLGNg4hu5eKA==",
-      "peer": true,
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/common-types/-/common-types-1.48.0.tgz",
+      "integrity": "sha512-3IB8mmYtIS1b6pZXx6C0enw3OoJDMASFgTW75KVj8IWwIoQkCAM/YN0p8oiYrar4lVnaLkSn76ERrPaHU1Fx3g==",
       "requires": {}
     },
     "@arianee/contracts": {
@@ -9855,9 +9834,9 @@
       }
     },
     "@arianee/core": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/core/-/core-1.47.0.tgz",
-      "integrity": "sha512-tluRG0JVjmIE3Zz4m76izHhcSaUtBfg+GMrI5u3zpl+ChE91Vt662V/6NCqqeAI5EUnZZYAa9RohxMNtubMY8g==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/core/-/core-1.48.0.tgz",
+      "integrity": "sha512-wyAqNoEf5UO4bU1J41EYiDaRzJHZ5qMETRnz2P/F53nUb3bqPrfLzRMcgfHR1RxiAnYaryKh7Pe9O/GwwBvkYg==",
       "requires": {
         "ethers": "6.7.0"
       },
@@ -9901,9 +9880,9 @@
       }
     },
     "@arianee/creator": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/creator/-/creator-1.47.0.tgz",
-      "integrity": "sha512-IxlMPOb7iQPusWiMzluGCDGw7hS4uERA0jmBDgwJLHHuwSUyN0+wdyTOZksayHCKaXlqjp7rM/O60sBOPnbGIA==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/creator/-/creator-1.48.0.tgz",
+      "integrity": "sha512-XMCJEOnQtxnpbuY/1C+XZfSe3IgXLwUbhvhCdKYYBGzUs2F2WR8J8Bbwo1NTEXCo2LekbcMXnjsP9GBirI4N3w==",
       "requires": {
         "@arianee/0xcert-cert": "^2.0.2",
         "@arianee/arianee-abi": "0.22.0",
@@ -9972,9 +9951,9 @@
       }
     },
     "@arianee/permit721-sdk": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/permit721-sdk/-/permit721-sdk-1.47.0.tgz",
-      "integrity": "sha512-T7tBJGObeqbt4oPY2PcYjqIfOj6qXcbDLlQHe1qv0yBt2ARmx53NYSK+5dXbqgNvFVrvtl4wLOj+Y3nOa/Ryeg==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/permit721-sdk/-/permit721-sdk-1.48.0.tgz",
+      "integrity": "sha512-zY0uirzCjF7EfSAeCVABGOlsX8F0hvp9Y7Cz2PLXiRXN7ugg+1W+dOC20KaBU2whdYZxsaMzPZm5Sz0Fz5z+BA==",
       "peer": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -10028,10 +10007,9 @@
       }
     },
     "@arianee/token-provider": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/token-provider/-/token-provider-1.47.0.tgz",
-      "integrity": "sha512-hVDNiuH8QegM1rO5w7APy9TGTYTdw6luKt/4Xd4betFMJTCK50xnJq6y3JL/9E402U2ggjytgUPtOJOfoFsi8w==",
-      "dev": true,
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/token-provider/-/token-provider-1.48.0.tgz",
+      "integrity": "sha512-NjNSEFSYZBwPWSkuYfffSa+J1rml0NDSn2bFrcTWFA5LTf9IWRwOMTuoIP+XcgGzfW2DIutgcIe+9yc+3MuXOA==",
       "peer": true,
       "requires": {
         "@arianee/0xcert-cert": "^2.0.2",
@@ -10051,28 +10029,24 @@
           "version": "1.9.2",
           "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz",
           "integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==",
-          "dev": true,
           "peer": true
         },
         "@noble/hashes": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
           "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
-          "dev": true,
           "peer": true
         },
         "@types/node": {
           "version": "18.15.13",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
           "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
-          "dev": true,
           "peer": true
         },
         "ethers": {
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.7.0.tgz",
           "integrity": "sha512-pxt5hK82RNwcTX2gOZP81t6qVPVspnkpeivwEgQuK9XUvbNtghBnT8GNIb/gPh+WnVSfi8cXC9XlfT8sqc6D6w==",
-          "dev": true,
           "peer": true,
           "requires": {
             "@adraffy/ens-normalize": "1.9.2",
@@ -10088,7 +10062,6 @@
               "version": "2.4.0",
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
               "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-              "dev": true,
               "peer": true
             }
           }
@@ -10096,9 +10069,9 @@
       }
     },
     "@arianee/utils": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/utils/-/utils-1.47.0.tgz",
-      "integrity": "sha512-YkjRSRiqc4QoRsCjvecFVgyi6uhaFXtjSZDFy17DDN//hS2Qwpfx5SknnDEWK23CJINLhxQIzWhmm2hax0jsig==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/utils/-/utils-1.48.0.tgz",
+      "integrity": "sha512-pCUazyeJ6N0jRC6FLrQZfz4f8guEVxANXuFuFJyBbUDrU8Cp5rCR/0ExVQSBc3mIbsvN2O4ZLgXk/2HE8K9zkw==",
       "requires": {
         "@arianee/0xcert-cert": "^2.0.2",
         "@arianee/arianee-abi": "0.22.0",
@@ -10146,10 +10119,9 @@
       }
     },
     "@arianee/wallet": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/wallet/-/wallet-1.47.0.tgz",
-      "integrity": "sha512-Wq4VI9EXQ3wrs3bSUCqytJm2uPNovSwonqVaDulsL5BU+McVCRnZ8V1dZ5EFUEMLdzZLbphKbfcndpgWqdWGjg==",
-      "dev": true,
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/wallet/-/wallet-1.48.0.tgz",
+      "integrity": "sha512-Q6Z4bWldA/4oJCli6MvjzWyEw8cJIJUt/1gk0GU/ewhFXoQ6mL6u4pAFMmq6NaTk5GX0iHOTeas18ykDLFzEHg==",
       "requires": {
         "@arianee/0xcert-cert": "^2.0.2",
         "@arianee/arianee-abi": "0.22.0",
@@ -10168,26 +10140,22 @@
         "@adraffy/ens-normalize": {
           "version": "1.9.2",
           "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz",
-          "integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==",
-          "dev": true
+          "integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg=="
         },
         "@noble/hashes": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
-          "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
-          "dev": true
+          "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA=="
         },
         "@types/node": {
           "version": "18.15.13",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
-          "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
-          "dev": true
+          "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
         },
         "ethers": {
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.7.0.tgz",
           "integrity": "sha512-pxt5hK82RNwcTX2gOZP81t6qVPVspnkpeivwEgQuK9XUvbNtghBnT8GNIb/gPh+WnVSfi8cXC9XlfT8sqc6D6w==",
-          "dev": true,
           "requires": {
             "@adraffy/ens-normalize": "1.9.2",
             "@noble/hashes": "1.1.2",
@@ -10201,26 +10169,23 @@
             "tslib": {
               "version": "2.4.0",
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-              "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-              "dev": true
+              "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
             }
           }
         }
       }
     },
     "@arianee/wallet-abstraction": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/wallet-abstraction/-/wallet-abstraction-1.47.0.tgz",
-      "integrity": "sha512-qb5Y/OCqdy/YsCUTdlf/Bz1xXM0uG2TEfBJh8Wa20jWWOzwA9CpTKOgiqklyO2ufc+IDJ6G/+Q+dMts6Qh7+Eg==",
-      "dev": true,
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/wallet-abstraction/-/wallet-abstraction-1.48.0.tgz",
+      "integrity": "sha512-E79pfy+Au+2owpQrCwNz50aaIAmIbIGmFllHP0E7OJ7tIiXpbx+NbRkgBx0FZvMD2bI1PQeczIpRoKJZlim3FA==",
       "peer": true,
       "requires": {}
     },
     "@arianee/wallet-api-client": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@arianee/wallet-api-client/-/wallet-api-client-1.47.0.tgz",
-      "integrity": "sha512-0Oiv0dQVqR7yx+scol7lKYJXAJaCKKzaDkqWoWZGlFnxLbelGHJ2XUv19ePqn6UlBQLaiwSbunPa1dbyOUfV2w==",
-      "dev": true,
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@arianee/wallet-api-client/-/wallet-api-client-1.48.0.tgz",
+      "integrity": "sha512-IMKbT2wP0ZhKcj0U1VAq7dVdF7JhNdVdlEoVZcO7B5QMklqAExh15a/EmZoZtc4/Hxw5MGtJssgd2/VjwvfE7g==",
       "peer": true,
       "requires": {
         "@arianee/0xcert-cert": "^2.0.2",
@@ -10238,28 +10203,24 @@
           "version": "1.9.2",
           "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz",
           "integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg==",
-          "dev": true,
           "peer": true
         },
         "@noble/hashes": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
           "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
-          "dev": true,
           "peer": true
         },
         "@types/node": {
           "version": "18.15.13",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
           "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
-          "dev": true,
           "peer": true
         },
         "ethers": {
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.7.0.tgz",
           "integrity": "sha512-pxt5hK82RNwcTX2gOZP81t6qVPVspnkpeivwEgQuK9XUvbNtghBnT8GNIb/gPh+WnVSfi8cXC9XlfT8sqc6D6w==",
-          "dev": true,
           "peer": true,
           "requires": {
             "@adraffy/ens-normalize": "1.9.2",
@@ -10275,7 +10236,6 @@
               "version": "2.4.0",
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
               "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-              "dev": true,
               "peer": true
             }
           }
@@ -12786,8 +12746,7 @@
     "eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "dev": true
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "execa": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -23,13 +23,15 @@
     "url": "https://github.com/Arianee/arianee-rpc-server"
   },
   "dependencies": {
-    "@arianee/arianee-access-token": "1.47.0",
-    "@arianee/arianee-api-client": "1.47.0",
-    "@arianee/arianee-privacy-gateway-client": "1.47.0",
-    "@arianee/arianee-protocol-client": "1.47.0",
-    "@arianee/core": "1.47.0",
-    "@arianee/creator": "1.47.0",
-    "@arianee/utils": "1.47.0",
+    "@arianee/arianee-access-token": "1.48.0",
+    "@arianee/arianee-api-client": "1.48.0",
+    "@arianee/arianee-privacy-gateway-client": "1.48.0",
+    "@arianee/arianee-protocol-client": "1.48.0",
+    "@arianee/common-types": "^1.48.0",
+    "@arianee/core": "1.48.0",
+    "@arianee/creator": "1.48.0",
+    "@arianee/utils": "1.48.0",
+    "@arianee/wallet": "1.48.0",
     "axios": "^1.6.0",
     "ethers": "^6.8.1",
     "express": "^4.18.2",
@@ -39,7 +41,6 @@
     "jrpc": "^3.1.2"
   },
   "devDependencies": {
-    "@arianee/wallet": "1.47.0",
     "@types/jest": "^29.5.8",
     "@types/node": "^12.20.55",
     "body-parser": "^1.20.2",

--- a/src/helpers/readCertificate.test.ts
+++ b/src/helpers/readCertificate.test.ts
@@ -1,8 +1,8 @@
 import { readCertificate } from './readCertificate';
 import { ArianeeApiClient } from '@arianee/arianee-api-client';
 import { ArianeeAccessToken } from '@arianee/arianee-access-token';
-import { ErrorEnum, getError } from '../rpc/errors/error';
-
+import { getError } from '../rpc/errors/error';
+import { PrivacyGatewayErrorEnum } from '@arianee/common-types';
 
 jest.mock('@arianee/arianee-api-client', () => {
   return {
@@ -22,17 +22,20 @@ jest.mock('@arianee/arianee-api-client', () => {
   };
 });
 jest.mock('@arianee/arianee-access-token');
-jest.mock('ethers', ()=>{
-  return{
-    ethers:{
-        verifyMessage:(message:string, signature:string)=>{
-          if(signature === "0x0de47a78ee3e683fdfa57c654e80e9d51aea1d6192c5dcd00d548d28e9383d3f42685c9a383549fdca36e89cc05bf4a4ff82ad4d18c1bc8094daa0f2f80ce5c61b"){
-            return "someOwner"
-          }
-          return "notOwner";
+jest.mock('ethers', () => {
+  return {
+    ethers: {
+      verifyMessage: (message: string, signature: string) => {
+        if (
+          signature ===
+          '0x0de47a78ee3e683fdfa57c654e80e9d51aea1d6192c5dcd00d548d28e9383d3f42685c9a383549fdca36e89cc05bf4a4ff82ad4d18c1bc8094daa0f2f80ce5c61b'
+        ) {
+          return 'someOwner';
         }
-    }
-  }
+        return 'notOwner';
+      },
+    },
+  };
 });
 describe('readCertificate', () => {
   let configuration: any;
@@ -146,7 +149,7 @@ describe('readCertificate', () => {
       await readCertificate(data, callback, configuration);
 
       // Expect the callback to be called with the NOTOWNERORISSUER error since the issuer doesn't match owner or issuer
-      expect(callback).toHaveBeenCalledWith(getError(ErrorEnum.NOTOWNERORISSUER));
+      expect(callback).toHaveBeenCalledWith(getError(PrivacyGatewayErrorEnum.NOTOWNERORISSUER));
     });
 
     test('should return an error with valid bearer when payload issuer is issuer but subId does not match certificateId', async () => {
@@ -161,7 +164,7 @@ describe('readCertificate', () => {
       await readCertificate(data, callback, configuration);
 
       // Expect the callback to be called with the WRONGJWT error since the subId doesn't match the certificateId
-      expect(callback).toHaveBeenCalledWith(getError(ErrorEnum.WRONGJWT));
+      expect(callback).toHaveBeenCalledWith(getError(PrivacyGatewayErrorEnum.WRONGJWT));
     });
 
     test('should return an error with valid bearer when payload issuer is owner but subId does not match certificateId', async () => {
@@ -176,7 +179,7 @@ describe('readCertificate', () => {
       await readCertificate(data, callback, configuration);
 
       // Expect the callback to be called with the WRONGJWT error since the subId doesn't match the certificateId
-      expect(callback).toHaveBeenCalledWith(getError(ErrorEnum.WRONGJWT));
+      expect(callback).toHaveBeenCalledWith(getError(PrivacyGatewayErrorEnum.WRONGJWT));
     });
 
     test('should return an error when bearer is invalid', async () => {
@@ -189,7 +192,7 @@ describe('readCertificate', () => {
       await readCertificate(data, callback, configuration);
 
       // Expect the callback to have been called with the WRONGJWT error
-      expect(callback).toHaveBeenCalledWith(getError(ErrorEnum.WRONGJWT));
+      expect(callback).toHaveBeenCalledWith(getError(PrivacyGatewayErrorEnum.WRONGJWT));
     });
   });
 
@@ -202,7 +205,8 @@ describe('readCertificate', () => {
         certificateId: '123',
         authentification: {
           message: 'someMessage',
-          signature: '0x262d6e00093044c5b3326372bdde4dddd39c91b4094fd253ecbbe4f593f7ecac66fe9fb95c37dee4722019d99f9d2dddbf328e838f5c65c7713cb9111f431ae31b',
+          signature:
+            '0x262d6e00093044c5b3326372bdde4dddd39c91b4094fd253ecbbe4f593f7ecac66fe9fb95c37dee4722019d99f9d2dddbf328e838f5c65c7713cb9111f431ae31b',
         },
       };
       configuration.fetchItem.mockResolvedValueOnce({ content: 'sample-content' });
@@ -214,7 +218,8 @@ describe('readCertificate', () => {
             certificateId: 123,
             timestamp: new Date().toISOString(), // Current timestamp
           }),
-          signature: '0x0de47a78ee3e683fdfa57c654e80e9d51aea1d6192c5dcd00d548d28e9383d3f42685c9a383549fdca36e89cc05bf4a4ff82ad4d18c1bc8094daa0f2f80ce5c61b',
+          signature:
+            '0x0de47a78ee3e683fdfa57c654e80e9d51aea1d6192c5dcd00d548d28e9383d3f42685c9a383549fdca36e89cc05bf4a4ff82ad4d18c1bc8094daa0f2f80ce5c61b',
         },
       };
 
@@ -231,7 +236,7 @@ describe('readCertificate', () => {
       await readCertificate(data, callback, configuration);
 
       // Expect the callback to have been called with the SIGNATURETOOOLD error
-      expect(callback).toHaveBeenCalledWith(getError(ErrorEnum.SIGNATURETOOOLD));
+      expect(callback).toHaveBeenCalledWith(getError(PrivacyGatewayErrorEnum.SIGNATURETOOOLD));
     });
 
     test('should succeed when the signature is valid and matches the issuer', async () => {
@@ -272,7 +277,7 @@ describe('readCertificate', () => {
       const data = {
         certificateId: '84801077',
         authentification: {
-          message: '{"certificateId":"84801077","timestamp":"'+timestamp+'"}',
+          message: '{"certificateId":"84801077","timestamp":"' + timestamp + '"}',
           signature:
             '0x0de47a78ee3e683fdfa57c654e80e9d51aea1d6192c5dcd00d548d28e9383d3f42685c9a383549fdca36e89cc05bf4a4ff82ad4d18c1bc8094daa0f2f80ce5c61b',
           messageHash: '0x0738b04b872fe8d68fa24c0ec3cd69a0ba15a78021c4e38ed4028c4ac80e0e72',

--- a/src/helpers/readCertificate.ts
+++ b/src/helpers/readCertificate.ts
@@ -1,102 +1,93 @@
-import {CertificatePayload} from '../rpc/models/certificates';
-import {SyncFunc} from '../rpc/models/func';
-import {ErrorEnum, getError} from '../rpc/errors/error';
-import {ReadConfiguration} from '../rpc/models/readConfiguration';
-import {ArianeeAccessToken} from '@arianee/arianee-access-token';
-import {ArianeeApiClient} from '@arianee/arianee-api-client';
-import {ethers} from 'ethers';
+import { CertificatePayload } from '../rpc/models/certificates';
+import { SyncFunc } from '../rpc/models/func';
+import { getError } from '../rpc/errors/error';
+import { ReadConfiguration } from '../rpc/models/readConfiguration';
+import { ArianeeAccessToken } from '@arianee/arianee-access-token';
+import { ArianeeApiClient } from '@arianee/arianee-api-client';
+import { ethers } from 'ethers';
+import { PrivacyGatewayErrorEnum } from '@arianee/common-types';
 const arianeeApiClient = new ArianeeApiClient();
 
 export const readCertificate = async (
-    data: CertificatePayload,
-    callback: SyncFunc,
-    configuration: ReadConfiguration
+  data: CertificatePayload,
+  callback: SyncFunc,
+  configuration: ReadConfiguration
 ) => {
-    const {fetchItem, network} = configuration;
+  const { fetchItem, network } = configuration;
 
+  const { certificateId, authentification } = data;
+  const { message, signature, bearer } = authentification;
 
+  const { issuer, owner, requestKey, viewKey, proofKey, imprint } =
+    await arianeeApiClient.network.getNft(network, certificateId);
 
-    const {certificateId, authentification} = data;
-    const {message, signature, bearer} = authentification;
+  const successCallBack = async () => {
+    try {
+      const content = await fetchItem(certificateId, imprint);
+      return callback(null, content);
+    } catch (err) {
+      return callback(getError(PrivacyGatewayErrorEnum.MAINERROR));
+    }
+  };
 
-    const {issuer, owner, requestKey, viewKey, proofKey, imprint} = await arianeeApiClient.network.getNft(
-        network,
-        certificateId
-    );
+  const lowercasedKeys = [requestKey, viewKey, proofKey].map((k) => (k ?? '').toLowerCase());
 
-    const successCallBack = async () => {
-        try {
-            const content = await fetchItem(certificateId, imprint);
-            return callback(null, content);
-        } catch (err) {
-            return callback(getError(ErrorEnum.MAINERROR));
-        }
-    };
+  const lowercasedOwner = owner.toLowerCase();
+  const lowercasedIssuer = issuer.toLowerCase();
 
-    const lowercasedKeys = [requestKey, viewKey, proofKey].map((k) => (k ?? '').toLowerCase());
-
-    const lowercasedOwner = owner.toLowerCase();
-    const lowercasedIssuer = issuer.toLowerCase();
-
-    if (bearer) {
-        let payload;
-        try {
-            payload = ArianeeAccessToken.decodeJwt(bearer).payload; // decode test that aat is valid and throw if not
-        } catch (e) {
-            return callback(getError(ErrorEnum.WRONGJWT));
-        }
-
-        const lowercasedPayloadIssuer = payload.iss.toLowerCase();
-        const isOwnerOrIssuerOfNft = (lowercasedPayloadIssuer === lowercasedOwner || lowercasedPayloadIssuer === lowercasedIssuer);
-
-        if(!isOwnerOrIssuerOfNft) {
-            return callback(getError(ErrorEnum.NOTOWNERORISSUER));
-        }
-
-        if (
-            +payload.subId === +certificateId
-        ) {
-            return successCallBack();
-        } else if (
-            payload.sub === 'wallet'
-        ) {
-            return successCallBack();
-        } else {
-            return callback(getError(ErrorEnum.WRONGJWT));
-        }
+  if (bearer) {
+    let payload;
+    try {
+      payload = ArianeeAccessToken.decodeJwt(bearer).payload; // decode test that aat is valid and throw if not
+    } catch (e) {
+      return callback(getError(PrivacyGatewayErrorEnum.WRONGJWT));
     }
 
-    if (message && signature) {
-        const lowercasedPublicKeyOfSigner = (
-            ethers.verifyMessage(message, signature) ?? ''
-        ).toLowerCase();
+    const lowercasedPayloadIssuer = payload.iss.toLowerCase();
+    const isOwnerOrIssuerOfNft =
+      lowercasedPayloadIssuer === lowercasedOwner || lowercasedPayloadIssuer === lowercasedIssuer;
 
-        const parsedMessage = JSON.parse(message);
-
-        if (+parsedMessage.certificateId !== +certificateId) {
-            return callback(getError(ErrorEnum.WRONGCERTIFICATEID));
-        }
-
-        const isSignatureTooOld =
-            (new Date().getTime() - new Date(parsedMessage.timestamp).getTime()) / 1000 > 300;
-
-        if (isSignatureTooOld) {
-            return callback(getError(ErrorEnum.SIGNATURETOOOLD));
-        }
-
-        if (lowercasedOwner === lowercasedPublicKeyOfSigner) {
-            return successCallBack();
-        }
-        else if (lowercasedIssuer === lowercasedPublicKeyOfSigner) {
-            return successCallBack();
-        }
-        else if (lowercasedKeys.includes(lowercasedPublicKeyOfSigner)) {
-            return successCallBack();
-        }
-        else {
-            return callback(getError(ErrorEnum.NOTOWNERORISSUER));
-        }
+    if (!isOwnerOrIssuerOfNft) {
+      return callback(getError(PrivacyGatewayErrorEnum.NOTOWNERORISSUER));
     }
 
-    return callback(getError(ErrorEnum.MAINERROR));
+    if (+payload.subId === +certificateId) {
+      return successCallBack();
+    } else if (payload.sub === 'wallet') {
+      return successCallBack();
+    } else {
+      return callback(getError(PrivacyGatewayErrorEnum.WRONGJWT));
+    }
+  }
+
+  if (message && signature) {
+    const lowercasedPublicKeyOfSigner = (
+      ethers.verifyMessage(message, signature) ?? ''
+    ).toLowerCase();
+
+    const parsedMessage = JSON.parse(message);
+
+    if (+parsedMessage.certificateId !== +certificateId) {
+      return callback(getError(PrivacyGatewayErrorEnum.WRONGCERTIFICATEID));
+    }
+
+    const isSignatureTooOld =
+      (new Date().getTime() - new Date(parsedMessage.timestamp).getTime()) / 1000 > 300;
+
+    if (isSignatureTooOld) {
+      return callback(getError(PrivacyGatewayErrorEnum.SIGNATURETOOOLD));
+    }
+
+    if (lowercasedOwner === lowercasedPublicKeyOfSigner) {
+      return successCallBack();
+    } else if (lowercasedIssuer === lowercasedPublicKeyOfSigner) {
+      return successCallBack();
+    } else if (lowercasedKeys.includes(lowercasedPublicKeyOfSigner)) {
+      return successCallBack();
+    } else {
+      return callback(getError(PrivacyGatewayErrorEnum.NOTOWNERORISSUER));
+    }
+  }
+
+  return callback(getError(PrivacyGatewayErrorEnum.MAINERROR));
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
 import { ArianeeRPCCustom } from './arianeeRPCServer';
 export { ArianeeRPCCustom };
-export { ErrorEnum } from './rpc/errors/error';

--- a/src/rpc/certificate/index.ts
+++ b/src/rpc/certificate/index.ts
@@ -1,93 +1,81 @@
-import {RPCNAME} from "../rpc-name";
-import {CertificatePayload, CertificatePayloadCreate} from "../models/certificates";
-import {SyncFunc} from "../models/func";
-import {ErrorEnum, getError} from "../errors/error";
-import {callBackFactory} from "../libs/callBackFactory";
-import {ReadConfiguration} from "../models/readConfiguration";
-import {readCertificate} from "../../helpers/readCertificate";
-import {calculateImprint} from "../../helpers/calculateImprint";
-import {ArianeeProtocolClient, callWrapper} from "@arianee/arianee-protocol-client"
-import Core from "@arianee/core";
+import { RPCNAME } from '../rpc-name';
+import { CertificatePayload, CertificatePayloadCreate } from '../models/certificates';
+import { SyncFunc } from '../models/func';
+import { getError } from '../errors/error';
+import { callBackFactory } from '../libs/callBackFactory';
+import { ReadConfiguration } from '../models/readConfiguration';
+import { readCertificate } from '../../helpers/readCertificate';
+import { calculateImprint } from '../../helpers/calculateImprint';
+import { ArianeeProtocolClient, callWrapper } from '@arianee/arianee-protocol-client';
+import Core from '@arianee/core';
+import { PrivacyGatewayErrorEnum } from '@arianee/common-types';
 
-const certificateRPCFactory = (configuration:ReadConfiguration) => {
-
-  const { createItem, createWithoutValidationOnBC} = configuration;
+const certificateRPCFactory = (configuration: ReadConfiguration) => {
+  const { createItem, createWithoutValidationOnBC } = configuration;
   const core = Core.fromRandom();
-  const arianeeProtocolClient = new ArianeeProtocolClient(core)
+  const arianeeProtocolClient = new ArianeeProtocolClient(core);
   /**
    * Create a certificate content in database
    * @param data
    * @param callback
    */
-  const create = async (data:CertificatePayloadCreate, callback:SyncFunc) => {
+  const create = async (data: CertificatePayloadCreate, callback: SyncFunc) => {
     const { certificateId, json } = data;
 
-    const [successCallBack, successCallBackWithoutValidation] = callBackFactory(callback)(
-        [
-          () => createItem(certificateId, json),
-          () => createWithoutValidationOnBC(certificateId, json)
-        ]);
+    const [successCallBack, successCallBackWithoutValidation] = callBackFactory(callback)([
+      () => createItem(certificateId, json),
+      () => createWithoutValidationOnBC(certificateId, json),
+    ]);
 
-    const isTokenIdExist = await callWrapper(
-        arianeeProtocolClient,
-        configuration.network,
-        {
-          protocolV1Action: async (protocolV1) => {
-            try{
-              await protocolV1.smartAssetContract.ownerOf(certificateId);
-              return true;
-            }
-            catch (e) {
-              return false;
-            }
-          },
-          protocolV2Action: async (protocolV2) => {
-            throw new Error('not yet implemented');
-          },
+    const isTokenIdExist = await callWrapper(arianeeProtocolClient, configuration.network, {
+      protocolV1Action: async (protocolV1) => {
+        try {
+          await protocolV1.smartAssetContract.ownerOf(certificateId);
+          return true;
+        } catch (e) {
+          return false;
         }
-    )
+      },
+      protocolV2Action: async (protocolV2) => {
+        throw new Error('not yet implemented');
+      },
+    });
 
-    const imprint = await callWrapper(
-        arianeeProtocolClient,
-        configuration.network,
-        {
-          protocolV1Action: async (protocolV1) => protocolV1.smartAssetContract.tokenImprint(certificateId),
-          protocolV2Action: async (protocolV2) => {
-            throw new Error('not yet implemented');
-          },
-        }
-    )
-
+    const imprint = await callWrapper(arianeeProtocolClient, configuration.network, {
+      protocolV1Action: async (protocolV1) =>
+        protocolV1.smartAssetContract.tokenImprint(certificateId),
+      protocolV2Action: async (protocolV2) => {
+        throw new Error('not yet implemented');
+      },
+    });
 
     const createCertificateIfTokenIdExist = async () => {
       try {
-          // case of reserved token
-          if (imprint === '0x0000000000000000000000000000000000000000000000000000000000000000'
-              && createWithoutValidationOnBC) {
-            return successCallBackWithoutValidation();
-          }
+        // case of reserved token
+        if (
+          imprint === '0x0000000000000000000000000000000000000000000000000000000000000000' &&
+          createWithoutValidationOnBC
+        ) {
+          return successCallBackWithoutValidation();
+        }
 
-        const imprintCalculated= await calculateImprint(json);
+        const imprintCalculated = await calculateImprint(json);
         if (imprintCalculated === imprint) {
-            return successCallBack();
+          return successCallBack();
         } else {
-            return callback(getError(ErrorEnum.WRONGIMPRINT));
+          return callback(getError(PrivacyGatewayErrorEnum.WRONGIMPRINT));
         }
       } catch (e) {
-        return callback(getError(ErrorEnum.WRONGIMPRINT));
+        return callback(getError(PrivacyGatewayErrorEnum.WRONGIMPRINT));
       }
-
-    }
+    };
 
     if (!isTokenIdExist && createWithoutValidationOnBC) {
-      return successCallBackWithoutValidation()
-    } else{
-      return createCertificateIfTokenIdExist()
-
+      return successCallBackWithoutValidation();
+    } else {
+      return createCertificateIfTokenIdExist();
     }
-
   };
-
 
   /**
    * Read a certificate in database
@@ -95,13 +83,12 @@ const certificateRPCFactory = (configuration:ReadConfiguration) => {
    * @param callback
    */
   const read = async (data: CertificatePayload, callback: SyncFunc) => {
-   return readCertificate(data, callback, configuration);
+    return readCertificate(data, callback, configuration);
   };
-
 
   return {
     [RPCNAME.certificate.create]: create,
-    [RPCNAME.certificate.read]: read
+    [RPCNAME.certificate.read]: read,
   };
 };
 

--- a/src/rpc/errors/error.ts
+++ b/src/rpc/errors/error.ts
@@ -1,33 +1,21 @@
-import {isDebug} from "../libs/isDebugMode";
+import { PrivacyGatewayErrorEnum } from "@arianee/common-types";
 
-export enum ErrorEnum {
-    MAINERROR='MAINERROR',
-    CALLBACKIMPLEMENTATION='CALLBACKIMPLEMENTATION',
-    WRONGCERTIFICATEID='WRONGCERTIFICATEID',
-    SIGNATURETOOOLD='SIGNATURETOOOLD',
-    WRONGIMPRINT='WRONGIMPRINT',
-    JSONSCHEMA='JSONSCHEMA',
-    WRONGMESSAGEID='WRONGMESSAGEID',
-    WRONGJWT = "WRONGJWT",
-    NOCERTIFICATE = "NOCERTIFICATE",
-    NOTOWNERORISSUER = "NOTOWNERORISSUER"
 
-}
 
 const errorLog={
-   [ErrorEnum.MAINERROR]  : { code: 0, message: "unauthorized" },
-   [ErrorEnum.CALLBACKIMPLEMENTATION]  : { code: 1, message: "callback implementation throw error" },
-   [ErrorEnum.WRONGCERTIFICATEID]  : { code: 2, message: "certificateId in header and data are not the same " },
-   [ErrorEnum.SIGNATURETOOOLD]  : { code: 3, message: "signature authorization is too old " },
-   [ErrorEnum.WRONGIMPRINT]  : { code: 4, message: "Imprint does not match content" },
-   [ErrorEnum.JSONSCHEMA]  : { code: 5, message: "JSON Schema is unreachable" },
-   [ErrorEnum.WRONGMESSAGEID]  : { code: 6, message: "messageId in header and data are not the same " },
-   [ErrorEnum.WRONGJWT]  : { code: 7, message: "the JWT is not valid" },
-   [ErrorEnum.NOCERTIFICATE]  : { code: 8, message: "the certificate doesn\'t exist" },
-   [ErrorEnum.NOTOWNERORISSUER]  : { code: 9, message: "the issuer of the JWT is neither the owner nor the issuer of the nft" }
+   [PrivacyGatewayErrorEnum.MAINERROR]  : { code: 0, message: "unauthorized" },
+   [PrivacyGatewayErrorEnum.CALLBACKIMPLEMENTATION]  : { code: 1, message: "callback implementation throw error" },
+   [PrivacyGatewayErrorEnum.WRONGCERTIFICATEID]  : { code: 2, message: "certificateId in header and data are not the same " },
+   [PrivacyGatewayErrorEnum.SIGNATURETOOOLD]  : { code: 3, message: "signature authorization is too old " },
+   [PrivacyGatewayErrorEnum.WRONGIMPRINT]  : { code: 4, message: "Imprint does not match content" },
+   [PrivacyGatewayErrorEnum.JSONSCHEMA]  : { code: 5, message: "JSON Schema is unreachable" },
+   [PrivacyGatewayErrorEnum.WRONGMESSAGEID]  : { code: 6, message: "messageId in header and data are not the same " },
+   [PrivacyGatewayErrorEnum.WRONGJWT]  : { code: 7, message: "the JWT is not valid" },
+   [PrivacyGatewayErrorEnum.NOCERTIFICATE]  : { code: 8, message: "the certificate doesn\'t exist" },
+   [PrivacyGatewayErrorEnum.NOTOWNERORISSUER]  : { code: 9, message: "the issuer of the JWT is neither the owner nor the issuer of the nft" }
 
 }
 
-export const getError=(error:ErrorEnum)=>{
+export const getError=(error:PrivacyGatewayErrorEnum)=>{
     return errorLog[error];
 }

--- a/src/rpc/events/index.ts
+++ b/src/rpc/events/index.ts
@@ -1,147 +1,151 @@
-import {RPCNAME} from "../rpc-name";
-import {EventPayload, EventPayloadCreate} from "../models/events";
-import {ErrorEnum, getError} from "../errors/error";
-import {callBackFactory} from "../libs/callBackFactory";
-import {ReadConfiguration} from "../models/readConfiguration";
-import {ArianeeAccessToken} from "@arianee/arianee-access-token";
-import {ArianeeApiClient} from "@arianee/arianee-api-client";
-import {calculateImprint} from "../../helpers/calculateImprint";
-import {ethers} from "ethers";
-import {ArianeeProtocolClient, callWrapper} from "@arianee/arianee-protocol-client";
-import Core from "@arianee/core";
+import { RPCNAME } from '../rpc-name';
+import { EventPayload, EventPayloadCreate } from '../models/events';
+import { getError } from '../errors/error';
+import { callBackFactory } from '../libs/callBackFactory';
+import { ReadConfiguration } from '../models/readConfiguration';
+import { ArianeeAccessToken } from '@arianee/arianee-access-token';
+import { ArianeeApiClient } from '@arianee/arianee-api-client';
+import { calculateImprint } from '../../helpers/calculateImprint';
+import { ethers } from 'ethers';
+import { ArianeeProtocolClient, callWrapper } from '@arianee/arianee-protocol-client';
+import Core from '@arianee/core';
+import { PrivacyGatewayErrorEnum } from '@arianee/common-types';
 
 const arianeeApiClient = new ArianeeApiClient();
 
 const eventRPCFactory = (configuration: ReadConfiguration) => {
-    const {fetchItem, createItem, network, createWithoutValidationOnBC} = configuration;
-    const core = Core.fromRandom();
-    const arianeeProtocolClient = new ArianeeProtocolClient(core)
-    const create = async (data: EventPayloadCreate, callback) => {
-        const {eventId, json} = data;
+  const { fetchItem, createItem, network, createWithoutValidationOnBC } = configuration;
+  const core = Core.fromRandom();
+  const arianeeProtocolClient = new ArianeeProtocolClient(core);
+  const create = async (data: EventPayloadCreate, callback) => {
+    const { eventId, json } = data;
 
-        const [successCallBack, successCallbackWithoutValidation] = callBackFactory(callback)([
-            () => createItem(eventId, json),
-            () => createWithoutValidationOnBC(eventId, json),
-        ]);
+    const [successCallBack, successCallbackWithoutValidation] = callBackFactory(callback)([
+      () => createItem(eventId, json),
+      () => createWithoutValidationOnBC(eventId, json),
+    ]);
 
-        const event = await callWrapper(arianeeProtocolClient, configuration.network, {
-            protocolV1Action: async (protocolV1) => protocolV1.eventContract.getFunction('getEvent')(eventId)
-                .catch(() => undefined),
-            protocolV2Action: async (protocolV2) => {
-                throw new Error('not yet implemented');
-            },
-        });
+    const event = await callWrapper(arianeeProtocolClient, configuration.network, {
+      protocolV1Action: async (protocolV1) =>
+        protocolV1.eventContract
+          .getFunction('getEvent')(eventId)
+          .catch(() => undefined),
+      protocolV2Action: async (protocolV2) => {
+        throw new Error('not yet implemented');
+      },
+    });
 
-        if (event === undefined && createWithoutValidationOnBC) {
-            return successCallbackWithoutValidation()
+    if (event === undefined && createWithoutValidationOnBC) {
+      return successCallbackWithoutValidation();
+    } else {
+      try {
+        const imprint = event[1];
+        const calculatedImprint = await calculateImprint(json);
+        if (imprint === calculatedImprint) {
+          return successCallBack();
         } else {
-            try {
-                const imprint = event[1];
-                const calculatedImprint=await calculateImprint(json);
-                if (imprint === calculatedImprint) {
-                    return successCallBack();
-                } else {
-                    return callback(getError(ErrorEnum.MAINERROR));
-
-                }
-            } catch (err) {
-                return callback(getError(ErrorEnum.MAINERROR));
-            }
+          return callback(getError(PrivacyGatewayErrorEnum.MAINERROR));
         }
+      } catch (err) {
+        return callback(getError(PrivacyGatewayErrorEnum.MAINERROR));
+      }
+    }
+  };
+
+  const read = async (data: EventPayload, callback) => {
+    const successCallBack = async () => {
+      try {
+        const content = await fetchItem(eventId);
+        return callback(null, content);
+      } catch (err) {
+        return callback(getError(PrivacyGatewayErrorEnum.MAINERROR));
+      }
     };
 
-    const read = async (data: EventPayload, callback) => {
-        const successCallBack = async () => {
-            try {
-                const content = await fetchItem(eventId);
-                return callback(null, content);
-            } catch (err) {
-                return callback(getError(ErrorEnum.MAINERROR));
-            }
-        };
+    const { certificateId, authentification, eventId } = data;
+    const { message, signature, bearer } = authentification;
 
+    const { issuer, owner, requestKey, viewKey, proofKey } = await arianeeApiClient.network.getNft(
+      network,
+      certificateId
+    );
 
-        const {certificateId, authentification, eventId} = data;
-        const {message, signature, bearer} = authentification;
+    if (bearer) {
+      let payload;
+      try {
+        payload = ArianeeAccessToken.decodeJwt(bearer).payload; // decode test that aat is valid and throw if not
+      } catch (e) {
+        return callback(getError(PrivacyGatewayErrorEnum.WRONGJWT));
+      }
 
-        const {issuer, owner, requestKey, viewKey, proofKey} = await arianeeApiClient.network.getNft(
-            network,
-            certificateId
-        );
+      const payloadIssuerLowerCase = payload.iss.toLowerCase();
+      const nftOwnerLowerCase = owner.toLowerCase();
+      const nftIssuerLowerCase = issuer.toLowerCase();
 
-        if (bearer) {
-            let payload;
-            try {
-                payload = ArianeeAccessToken.decodeJwt(bearer).payload;   // decode test that aat is valid and throw if not
-            } catch (e) {
-                return callback(getError(ErrorEnum.WRONGJWT));
-            }
+      if (
+        payload.subId === certificateId &&
+        (payloadIssuerLowerCase === nftOwnerLowerCase ||
+          payloadIssuerLowerCase === nftIssuerLowerCase)
+      ) {
+        return successCallBack();
+      } else if (
+        payload.sub === 'wallet' &&
+        (payloadIssuerLowerCase === nftOwnerLowerCase ||
+          payloadIssuerLowerCase === nftIssuerLowerCase)
+      ) {
+        return successCallBack();
+      } else {
+        return callback(getError(PrivacyGatewayErrorEnum.WRONGJWT));
+      }
+    }
 
-            const payloadIssuerLowerCase = payload.iss.toLowerCase();
-            const nftOwnerLowerCase = owner.toLowerCase();
-            const nftIssuerLowerCase = issuer.toLowerCase();
+    if (message && signature) {
+      const publicAddressOfSender = ethers.verifyMessage(message, signature);
 
-            if (payload.subId === certificateId && (payloadIssuerLowerCase === nftOwnerLowerCase || payloadIssuerLowerCase === nftIssuerLowerCase)) {
-                return successCallBack();
-            } else if (payload.sub === 'wallet' && (payloadIssuerLowerCase === nftOwnerLowerCase || payloadIssuerLowerCase === nftIssuerLowerCase)) {
-                return successCallBack();
-            } else {
-                return callback(getError(ErrorEnum.WRONGJWT));
-            }
-        }
+      const parsedMessage = JSON.parse(message);
 
-        if (message && signature) {
-            const publicAddressOfSender = ethers.verifyMessage(message, signature);
+      if (parsedMessage.certificateId !== certificateId) {
+        return callback(getError(PrivacyGatewayErrorEnum.MAINERROR));
+      }
 
-            const parsedMessage = JSON.parse(message);
+      const isSignatureTooOld =
+        (new Date().getTime() - new Date(message.timestamp).getTime()) / 1000 > 300;
 
-            if (parsedMessage.certificateId !== certificateId) {
-                return callback(getError(ErrorEnum.MAINERROR));
+      if (isSignatureTooOld) {
+        return callback(getError(PrivacyGatewayErrorEnum.MAINERROR));
+      }
 
-            }
+      // Is the event exist
+      try {
+        await arianeeApiClient.network.getArianeeEvent(configuration.network, eventId);
+      } catch (err) {
+        return callback(getError(PrivacyGatewayErrorEnum.MAINERROR));
+      }
 
-            const isSignatureTooOld =
-                (new Date().getTime() - new Date(message.timestamp).getTime()) / 1000 >
-                300;
+      // Is user the owner of this certificate
+      if (owner.toLowerCase() === publicAddressOfSender.toLowerCase()) {
+        return successCallBack();
+      }
 
-            if (isSignatureTooOld) {
-                return callback(getError(ErrorEnum.MAINERROR));
+      // Is user the issuer of this certificate
 
-            }
+      if (issuer.toLowerCase() === publicAddressOfSender.toLowerCase()) {
+        return successCallBack();
+      }
 
-            // Is the event exist
-            try {
-                await arianeeApiClient.network.getArianeeEvent(configuration.network, eventId)
-            } catch (err) {
-                return callback(getError(ErrorEnum.MAINERROR));
-            }
+      const lowercasedKeys = [requestKey, viewKey, proofKey].map((k) => (k ?? '').toLowerCase());
+      if (lowercasedKeys.includes(publicAddressOfSender.toLowerCase())) {
+        return successCallBack();
+      }
+    }
 
+    return callback(getError(PrivacyGatewayErrorEnum.MAINERROR));
+  };
 
-            // Is user the owner of this certificate
-            if (owner.toLowerCase() === publicAddressOfSender.toLowerCase()) {
-                return successCallBack();
-            }
-
-            // Is user the issuer of this certificate
-
-            if (issuer.toLowerCase() === publicAddressOfSender.toLowerCase()) {
-                return successCallBack();
-            }
-
-            const lowercasedKeys = [requestKey, viewKey, proofKey].map((k) => (k ?? '').toLowerCase());
-            if (lowercasedKeys.includes(publicAddressOfSender.toLowerCase())) {
-                return successCallBack();
-            }
-        }
-
-        return callback(getError(ErrorEnum.MAINERROR));
-
-    };
-
-    return {
-        [RPCNAME.event.create]: create,
-        [RPCNAME.event.read]: read
-    };
+  return {
+    [RPCNAME.event.create]: create,
+    [RPCNAME.event.read]: read,
+  };
 };
 
-export {eventRPCFactory};
+export { eventRPCFactory };

--- a/src/rpc/libs/callBackFactory.ts
+++ b/src/rpc/libs/callBackFactory.ts
@@ -1,15 +1,14 @@
-import {ErrorEnum, getError} from "../errors/error";
+import { PrivacyGatewayErrorEnum } from '@arianee/common-types';
+import { getError } from '../errors/error';
 
 export const callBackFactory = (RPCCallback) => (functionToCalls: any[]) => {
-    return functionToCalls
-        .map(functionToCall => async () => {
-            try {
-                const result = await functionToCall();
-                return RPCCallback(null, result);
-            } catch (err) {
-              console.log('err', err)
-                return RPCCallback(getError(ErrorEnum.CALLBACKIMPLEMENTATION));
-            }
-        })
-
+  return functionToCalls.map((functionToCall) => async () => {
+    try {
+      const result = await functionToCall();
+      return RPCCallback(null, result);
+    } catch (err) {
+      console.log('err', err);
+      return RPCCallback(getError(PrivacyGatewayErrorEnum.CALLBACKIMPLEMENTATION));
+    }
+  });
 };

--- a/src/rpc/messages/index.ts
+++ b/src/rpc/messages/index.ts
@@ -1,136 +1,134 @@
-import {RPCNAME} from "../rpc-name";
+import { RPCNAME } from '../rpc-name';
 import axios from 'axios';
-import {MessagePayload, MessagePayloadCreate} from "../models/messages";
-import {ErrorEnum, getError} from "../errors/error";
-import {callBackFactory} from "../libs/callBackFactory";
-import {ReadConfiguration} from "../models/readConfiguration";
-import {ArianeeAccessToken} from "@arianee/arianee-access-token";
-import {ArianeeApiClient} from "@arianee/arianee-api-client";
-import {ethers} from "ethers";
-import {calculateImprint} from "../../helpers/calculateImprint";
-import Core from "@arianee/core";
-import {ArianeeProtocolClient, callWrapper} from "@arianee/arianee-protocol-client";
+import { MessagePayload, MessagePayloadCreate } from '../models/messages';
+import { getError } from '../errors/error';
+import { callBackFactory } from '../libs/callBackFactory';
+import { ReadConfiguration } from '../models/readConfiguration';
+import { ArianeeAccessToken } from '@arianee/arianee-access-token';
+import { ArianeeApiClient } from '@arianee/arianee-api-client';
+import { ethers } from 'ethers';
+import { calculateImprint } from '../../helpers/calculateImprint';
+import Core from '@arianee/core';
+import { ArianeeProtocolClient, callWrapper } from '@arianee/arianee-protocol-client';
+import { PrivacyGatewayErrorEnum } from '@arianee/common-types';
 
 const arianeeApiClient = new ArianeeApiClient();
 
-
 const messageRPCFactory = (configuration: ReadConfiguration) => {
+  const { fetchItem, createItem, network, createWithoutValidationOnBC } = configuration;
+  const core = Core.fromRandom();
+  const arianeeProtocolClient = new ArianeeProtocolClient(core);
+  const create = async (data: MessagePayloadCreate, callback) => {
+    const [successCallBack, sucessCallBackWithoutValidationOnBC] = callBackFactory(callback)([
+      () => createItem(messageId, json),
+      () => createWithoutValidationOnBC(messageId, json),
+    ]);
 
-    const {fetchItem, createItem, network, createWithoutValidationOnBC} = configuration;
-    const core = Core.fromRandom();
-    const arianeeProtocolClient = new ArianeeProtocolClient(core)
-    const create = async (data: MessagePayloadCreate, callback) => {
+    const { messageId, json } = data;
 
-        const [successCallBack, sucessCallBackWithoutValidationOnBC] = callBackFactory(callback)([
-            () => createItem(messageId, json),
-            () => createWithoutValidationOnBC(messageId, json),
+    const message = await callWrapper(arianeeProtocolClient, configuration.network, {
+      protocolV1Action: async (protocolV1) =>
+        protocolV1.messageContract.messages(messageId).catch(() => undefined),
+      protocolV2Action: async (protocolV2) => {
+        throw new Error('not yet implemented');
+      },
+    });
 
-        ]);
-
-        const {messageId, json} = data;
-
-        const message = await callWrapper(arianeeProtocolClient, configuration.network, {
-            protocolV1Action: async (protocolV1) =>
-                protocolV1.messageContract.messages(messageId)
-                    .catch(() => undefined),
-            protocolV2Action: async (protocolV2) => {
-                throw new Error('not yet implemented');
-            },
-        });
-
-
-        if (message.imprint === '0x0000000000000000000000000000000000000000000000000000000000000000' && createWithoutValidationOnBC) {
-            return sucessCallBackWithoutValidationOnBC()
+    if (
+      message.imprint === '0x0000000000000000000000000000000000000000000000000000000000000000' &&
+      createWithoutValidationOnBC
+    ) {
+      return sucessCallBackWithoutValidationOnBC();
+    } else {
+      try {
+        const imprint = await calculateImprint(json);
+        if (message.imprint === imprint) {
+          return successCallBack();
         } else {
-            try {
-                const imprint = await calculateImprint(json);
-                if (message.imprint === imprint) {
-                    return successCallBack();
-                } else {
-                    return callback(getError(ErrorEnum.WRONGIMPRINT));
-                }
-            } catch (err) {
-                return callback(getError(ErrorEnum.WRONGMESSAGEID));
-            }
+          return callback(getError(PrivacyGatewayErrorEnum.WRONGIMPRINT));
         }
+      } catch (err) {
+        return callback(getError(PrivacyGatewayErrorEnum.WRONGMESSAGEID));
+      }
+    }
+  };
+
+  const read = async (data: MessagePayload, callback) => {
+    const successCallBack = async () => {
+      try {
+        const content = await fetchItem(messageId);
+        return callback(null, content);
+      } catch (err) {
+        return callback(getError(PrivacyGatewayErrorEnum.MAINERROR));
+      }
     };
 
-    const read = async (data: MessagePayload, callback) => {
-        const successCallBack = async () => {
-            try {
-                const content = await fetchItem(messageId);
-                return callback(null, content);
-            } catch (err) {
-                return callback(getError(ErrorEnum.MAINERROR));
+    const { authentification, messageId } = data;
+    const { message, signature, bearer } = authentification;
 
-            }
-        };
+    const messageBc = await arianeeApiClient.network.getMessage(configuration.network, messageId);
 
+    if (bearer) {
+      let payload;
+      try {
+        payload = ArianeeAccessToken.decodeJwt(bearer).payload; // decode test that aat is valid and throw if not
+      } catch (e) {
+        return callback(getError(PrivacyGatewayErrorEnum.WRONGJWT));
+      }
 
-        const {authentification, messageId} = data;
-        const {message, signature, bearer} = authentification;
+      const payloadIssuerLowerCase = payload.iss.toLowerCase();
+      const receiverLowerCase = messageBc.receiver.toLowerCase();
+      const senderLowerCase = messageBc.sender.toLowerCase();
 
-        const messageBc = await arianeeApiClient.network.getMessage(
-            configuration.network,
-            messageId
-        )
+      if (
+        payloadIssuerLowerCase === messageBc.receiver &&
+        payloadIssuerLowerCase === receiverLowerCase
+      ) {
+        return successCallBack();
+      } else if (
+        payload.sub === 'wallet' &&
+        (payloadIssuerLowerCase === receiverLowerCase || payloadIssuerLowerCase === senderLowerCase)
+      ) {
+        return successCallBack();
+      } else {
+        return callback(getError(PrivacyGatewayErrorEnum.WRONGJWT));
+      }
+    }
 
-        if (bearer) {
-            let payload;
-            try {
-                payload = ArianeeAccessToken.decodeJwt(bearer).payload;   // decode test that aat is valid and throw if not
-            } catch (e) {
-                return callback(getError(ErrorEnum.WRONGJWT));
-            }
+    const publicAddressOfSender = ethers.verifyMessage(message, signature);
 
-            const payloadIssuerLowerCase = payload.iss.toLowerCase();
-            const receiverLowerCase = messageBc.receiver.toLowerCase();
-            const senderLowerCase = messageBc.sender.toLowerCase();
+    const parsedMessage = JSON.parse(message);
+    const isSignatureTooOld =
+      (new Date().getTime() - new Date(parsedMessage.timestamp).getTime()) / 1000 > 300;
 
-            if (payloadIssuerLowerCase === messageBc.receiver && payloadIssuerLowerCase === receiverLowerCase) {
-                return successCallBack();
-            } else if (payload.sub === 'wallet' && (payloadIssuerLowerCase === receiverLowerCase || payloadIssuerLowerCase === senderLowerCase)){
-                return successCallBack();
-            } else {
-                return callback(getError(ErrorEnum.WRONGJWT));
-            }
-        }
+    if (isSignatureTooOld) {
+      return callback(getError(PrivacyGatewayErrorEnum.MAINERROR));
+    }
 
-        const publicAddressOfSender = ethers.verifyMessage(message, signature);
+    // Is the message exist
+    try {
+      const arianeeMessage = await arianeeApiClient.network.getMessage(
+        configuration.network,
+        messageId
+      );
+      if (
+        !arianeeMessage &&
+        arianeeMessage.receiver.toLowerCase() !== publicAddressOfSender.toLowerCase() &&
+        arianeeMessage.sender.toLowerCase() !== publicAddressOfSender.toLowerCase()
+      ) {
+        return callback(getError(PrivacyGatewayErrorEnum.MAINERROR));
+      } else {
+        return successCallBack();
+      }
+    } catch (err) {
+      return callback(getError(PrivacyGatewayErrorEnum.MAINERROR));
+    }
+  };
 
-
-        const parsedMessage = JSON.parse(message);
-        const isSignatureTooOld =
-            (new Date().getTime() - new Date(parsedMessage.timestamp).getTime()) / 1000 >
-            300;
-
-        if (isSignatureTooOld) {
-            return callback(getError(ErrorEnum.MAINERROR));
-        }
-
-        // Is the message exist
-        try {
-
-            const arianeeMessage = await arianeeApiClient.network.getMessage(
-                configuration.network,
-                messageId
-            )
-            if (!arianeeMessage && arianeeMessage.receiver.toLowerCase() !== publicAddressOfSender.toLowerCase() && arianeeMessage.sender.toLowerCase() !== publicAddressOfSender.toLowerCase()) {
-                return callback(getError(ErrorEnum.MAINERROR));
-            } else {
-                return successCallBack();
-            }
-
-        } catch (err) {
-            return callback(getError(ErrorEnum.MAINERROR));
-        }
-
-    };
-
-    return {
-        [RPCNAME.message.create]: create,
-        [RPCNAME.message.read]: read
-    };
+  return {
+    [RPCNAME.message.create]: create,
+    [RPCNAME.message.read]: read,
+  };
 };
 
-export {messageRPCFactory};
+export { messageRPCFactory };

--- a/src/rpc/update/index.ts
+++ b/src/rpc/update/index.ts
@@ -1,6 +1,6 @@
 import {CertificatePayload, CertificatePayloadCreate} from "../models/certificates";
 import {SyncFunc} from "../models/func";
-import {ErrorEnum, getError} from "../errors/error";
+import { getError} from "../errors/error";
 import {callBackFactory} from "../libs/callBackFactory";
 import {RPCNAME} from "../rpc-name";
 import {readCertificate} from "../../helpers/readCertificate";
@@ -8,6 +8,7 @@ import {ReadConfiguration} from "../models/readConfiguration";
 import {calculateImprint} from "../../helpers/calculateImprint";
 import Core from "@arianee/core";
 import {ArianeeProtocolClient, callWrapper} from "@arianee/arianee-protocol-client";
+import { PrivacyGatewayErrorEnum } from "@arianee/common-types";
 
 const updateRPCFactory = (configuration: ReadConfiguration) => {
 
@@ -46,9 +47,9 @@ const updateRPCFactory = (configuration: ReadConfiguration) => {
                 return successCallBackWithoutValidation();
             }
 
-            return callback(getError(ErrorEnum.MAINERROR));
+            return callback(getError(PrivacyGatewayErrorEnum.MAINERROR));
         } catch (e) {
-            return callback(getError(ErrorEnum.NOCERTIFICATE));
+            return callback(getError(PrivacyGatewayErrorEnum.NOCERTIFICATE));
         }
 
     }


### PR DESCRIPTION
This PR replaces all occurrences of `ErrorEnum` by `PrivacyGatewayErrorEnum` (from `@arianee/common-types`), this is because it's needed in some parts of the sdk, and to prevent a circular dependency, this type had to be extracted from this lib.

Keys and values remain unchanged and the behaviour is the same as before, only the location of the enum has changed.

