### PR TITLE
feat(rpc): enhance event authorization logic with additional checks

### DIFF
--- a/e2e/events-create.test.ts
+++ b/e2e/events-create.test.ts
@@ -1,12 +1,12 @@
-import {certificateContent} from "./mocks/certificateContent";
-import {cloneDeep} from 'lodash';
-import {eventContent} from "./mocks/eventContent";
+import { certificateContent } from "./mocks/certificateContent";
+import { cloneDeep } from 'lodash';
+import { eventContent } from "./mocks/eventContent";
 import axios from "axios";
 import Core from "@arianee/core";
 import Creator from "@arianee/creator";
 import Wallet from "@arianee/wallet";
-import {ArianeePrivacyGatewayClient} from "@arianee/arianee-privacy-gateway-client";
-import {ArianeeAccessToken} from "@arianee/arianee-access-token";
+import { ArianeePrivacyGatewayClient } from "@arianee/arianee-privacy-gateway-client";
+import { ArianeeAccessToken } from "@arianee/arianee-access-token";
 import { PrivacyGatewayError } from "@arianee/arianee-privacy-gateway-client/src/lib/errors/PrivacyGatewayError";
 
 describe('Event', () => {
@@ -16,50 +16,57 @@ describe('Event', () => {
     let arianeePrivacyGatewayClientOwner: ArianeePrivacyGatewayClient;
     let arianeePrivacyGatewayClientRandom: ArianeePrivacyGatewayClient;
     let arianeePrivacyGatewayClientIssuer: ArianeePrivacyGatewayClient;
+    let arianeePrivacyGatewayClientEventIssuer: ArianeePrivacyGatewayClient;
+
     let arianeeAccessTokenOwner: ArianeeAccessToken;
     let arianeeAccessTokenIssuer: ArianeeAccessToken;
+    let arianeeAccessTokenEventIssuer: ArianeeAccessToken;
 
     let arianeeEventId;
 
-    const ownerMnemonic = process.env.OWNERMNEMONIC;
-    const issuerMnemonic = process.env.ISSUERMNEMONIC;
+    const ownerMnemonic = process.env.OWNERMNEMONIC 
+    const issuerMnemonic = process.env.ISSUERMNEMONIC 
+    const eventIssuerMnemonic =process.env.EVENTISSUERMNEMONIC;
 
     beforeAll(async () => {
         try {
             const issuerCore = Core.fromMnemonic(issuerMnemonic!)
             const randomCore = Core.fromRandom();
             const ownerCore = Core.fromMnemonic(ownerMnemonic!);
+            const eventIssuerCore = Core.fromMnemonic(eventIssuerMnemonic!);
 
             arianeePrivacyGatewayClientOwner = new ArianeePrivacyGatewayClient(ownerCore)
             arianeePrivacyGatewayClientRandom = new ArianeePrivacyGatewayClient(randomCore);
             arianeePrivacyGatewayClientIssuer = new ArianeePrivacyGatewayClient(issuerCore);
+            arianeePrivacyGatewayClientEventIssuer = new ArianeePrivacyGatewayClient(eventIssuerCore);
+
 
             arianeeAccessTokenOwner = new ArianeeAccessToken(ownerCore)
             arianeeAccessTokenIssuer = new ArianeeAccessToken(issuerCore)
+            arianeeAccessTokenEventIssuer = new ArianeeAccessToken(eventIssuerCore)
 
             certificateId = 51628187;
             passphrase = "5mwtxt2sesau"
 
             console.info(`preparing wallets: DONE ${certificateId} ${passphrase}`);
-            console.log('preparing wallets: requesting ownership');
 
             arianeeEventId = "388334045"
-            await arianeePrivacyGatewayClientIssuer.eventCreate(process.env.rpcURL!, { eventId: arianeeEventId, content: eventContent});
+            await arianeePrivacyGatewayClientIssuer.eventCreate(process.env.rpcURL!, { eventId: arianeeEventId, content: eventContent });
 
-            await arianeePrivacyGatewayClientRandom.certificateCreate(process.env.rpcURL!, {certificateId, content: certificateContent});
+            await arianeePrivacyGatewayClientRandom.certificateCreate(process.env.rpcURL!, { certificateId, content: certificateContent });
         } catch (e) {
             console.error(e);
         }
     });
 
     test('should be able create content if content is equal to imprint', async () => {
-        await arianeePrivacyGatewayClientIssuer.eventCreate(process.env.rpcURL!, { eventId: arianeeEventId, content: eventContent})
+        await arianeePrivacyGatewayClientIssuer.eventCreate(process.env.rpcURL!, { eventId: arianeeEventId, content: eventContent })
         expect(true).toBeTruthy();
     });
 
 
     test('should NOT be able create content if content is not equal to imprint', async () => {
-        const eventContentClone  = {"$schema":"https://cert.arianee.org/version1/ArianeeEvent-i18n.json","title":"anothertitle"}
+        const eventContentClone = { "$schema": "https://cert.arianee.org/version1/ArianeeEvent-i18n.json", "title": "anothertitle" }
 
         try {
             await arianeePrivacyGatewayClientIssuer.eventCreate(process.env.rpcURL!, {
@@ -78,27 +85,27 @@ describe('Event', () => {
         let isInError = false;
         const eventContentClone = cloneDeep(eventContent);
         eventContentClone.title = 'anotherTitle';
-        await arianeePrivacyGatewayClientIssuer.eventCreate(process.env.rpcURL!, { eventId: "-1", content: eventContentClone})
+        await arianeePrivacyGatewayClientIssuer.eventCreate(process.env.rpcURL!, { eventId: "-1", content: eventContentClone })
         expect(true).toBeTruthy();
     });
     test('should be able get content (owner wallet)', async () => {
-        await arianeePrivacyGatewayClientOwner.eventCreate(process.env.rpcURL!, { eventId: arianeeEventId, content: eventContent})
-        const result = await arianeePrivacyGatewayClientOwner.eventRead(process.env.rpcURL!, {certificateId, eventId:arianeeEventId})
+        await arianeePrivacyGatewayClientOwner.eventCreate(process.env.rpcURL!, { eventId: arianeeEventId, content: eventContent })
+        const result = await arianeePrivacyGatewayClientOwner.eventRead(process.env.rpcURL!, { certificateId, eventId: arianeeEventId })
         expect(result).toEqual(eventContent);
 
     })
     test('should be able get content (issuer wallet)', async () => {
-        await arianeePrivacyGatewayClientIssuer.eventCreate(process.env.rpcURL!, { eventId: arianeeEventId, content: eventContent})
-        const result = await arianeePrivacyGatewayClientIssuer.eventRead(process.env.rpcURL!, {certificateId, eventId:arianeeEventId})
+        await arianeePrivacyGatewayClientIssuer.eventCreate(process.env.rpcURL!, { eventId: arianeeEventId, content: eventContent })
+        const result = await arianeePrivacyGatewayClientIssuer.eventRead(process.env.rpcURL!, { certificateId, eventId: arianeeEventId })
         expect(result).toEqual(eventContent);
     })
 
 
     test('should NOT be able get content (random wallet)', async () => {
-        await arianeePrivacyGatewayClientRandom.eventCreate(process.env.rpcURL!, { eventId: arianeeEventId, content: eventContent})
+        await arianeePrivacyGatewayClientRandom.eventCreate(process.env.rpcURL!, { eventId: arianeeEventId, content: eventContent })
 
         try {
-            await arianeePrivacyGatewayClientRandom.eventRead(process.env.rpcURL!, {certificateId, eventId:arianeeEventId})
+            await arianeePrivacyGatewayClientRandom.eventRead(process.env.rpcURL!, { certificateId, eventId: arianeeEventId })
         } catch (e) {
             expect(e).toBeInstanceOf(PrivacyGatewayError);
             expect((e as PrivacyGatewayError).message).toEqual("the JWT is not valid")
@@ -106,21 +113,29 @@ describe('Event', () => {
     })
 
     test('should be able get content with wallet access token from owner', async () => {
-        await arianeePrivacyGatewayClientIssuer.eventCreate(process.env.rpcURL!, { eventId: arianeeEventId, content: eventContent})
+        await arianeePrivacyGatewayClientIssuer.eventCreate(process.env.rpcURL!, { eventId: arianeeEventId, content: eventContent })
         const jwt = await arianeeAccessTokenOwner.createWalletAccessToken();
         const aatapgc = new ArianeePrivacyGatewayClient(jwt);
-        const result = await aatapgc.eventRead(process.env.rpcURL!, {certificateId, eventId:arianeeEventId})
+        const result = await aatapgc.eventRead(process.env.rpcURL!, { certificateId, eventId: arianeeEventId })
 
         expect(result).toEqual(eventContent);
     })
 
     test('should be able get content with wallet access token from issuer', async () => {
-        await arianeePrivacyGatewayClientIssuer.eventCreate(process.env.rpcURL!, { eventId: arianeeEventId, content: eventContent})
+        await arianeePrivacyGatewayClientIssuer.eventCreate(process.env.rpcURL!, { eventId: arianeeEventId, content: eventContent })
         const jwt = await arianeeAccessTokenIssuer.createWalletAccessToken();
         const aatapgc = new ArianeePrivacyGatewayClient(jwt);
-        const result = await aatapgc.eventRead(process.env.rpcURL!, {certificateId, eventId:arianeeEventId})
+        const result = await aatapgc.eventRead(process.env.rpcURL!, { certificateId, eventId: arianeeEventId })
 
         expect(result).toEqual(eventContent);
     })
 
+    test('should be able to get content if issuer of event', async () => {
+        const eventContent1 = { "$schema": "https://cert.arianee.org/version3/ArianeeEvent-i18n.json", "title": "Cet event est crée par arianee academy", "description": "Il est utilisé pour des tests e2e dans le repo arianee privacy gateway" };
+        await arianeePrivacyGatewayClientEventIssuer.eventCreate(process.env.rpcURL!, { eventId: "378866677", content: eventContent1 })
+        const jwt = await arianeeAccessTokenEventIssuer.createWalletAccessToken();
+        const aatapgc = new ArianeePrivacyGatewayClient(jwt);
+        const result = await aatapgc.eventRead(process.env.rpcURL!, { certificateId, eventId: '378866677' })
+        expect(result).toEqual(eventContent1);
+    })
 });


### PR DESCRIPTION
- Imported `ArianeeEvent` type for better type safety.
- Refactored authorization checks to include event issuer alongside NFT owner and issuer.
- Consolidated checks into a single array for allowed readers, improving readability and maintainability.
- Removed redundant checks for event existence and user ownership, streamlining the logic.
